### PR TITLE
fix dark mode for device assignment fields

### DIFF
--- a/app/templates/pin_list.html
+++ b/app/templates/pin_list.html
@@ -188,8 +188,8 @@
         {% endif %}
     </div>
 
-    <div class="col-sm-8" style="background-color:#eff0f2; border-radius:6px">
-        <div style="background-color:#eff0f2; border-radius:6px">
+    <div class="col-sm-8" style="border-radius:6px">
+        <div style="border-radius:6px">
             <div class="row col-sm-12">
 
         {% if this_sensor.hardware == 1 %}{# Pin #}


### PR DESCRIPTION
additional fix missed in #676; change from:
![2022-04-05 16 54 38 192 168 2 250 5e102c0fbc67](https://user-images.githubusercontent.com/10291736/161856174-546081ff-3bfd-4002-8b96-7eb01648af34.png)

to: 

![2022-04-05 16 54 49 192 168 2 250 72d2d4dd489b](https://user-images.githubusercontent.com/10291736/161856177-041d80a0-5e63-4afa-916a-de5b52309965.png)
